### PR TITLE
Change Item Lifespan to `Entity#lifespan` in Forge

### DIFF
--- a/common/src/main/java/io/github/strikerrocker/cleardespawn/IConfigHelper.java
+++ b/common/src/main/java/io/github/strikerrocker/cleardespawn/IConfigHelper.java
@@ -5,12 +5,7 @@ import net.minecraft.world.entity.item.ItemEntity;
 public interface IConfigHelper {
     int getFlashStartTime();
 
-    @Deprecated(forRemoval = true)
-    int getItemDespawnTime();
-
-    default int getItemDespawnTime(ItemEntity entity) {
-        return this.getItemDespawnTime();
-    }
+    int getItemDespawnTime(ItemEntity entity);
 
     boolean isUrgentFlashEnabled();
 }

--- a/common/src/main/java/io/github/strikerrocker/cleardespawn/IConfigHelper.java
+++ b/common/src/main/java/io/github/strikerrocker/cleardespawn/IConfigHelper.java
@@ -1,9 +1,16 @@
 package io.github.strikerrocker.cleardespawn;
 
+import net.minecraft.world.entity.item.ItemEntity;
+
 public interface IConfigHelper {
     int getFlashStartTime();
 
+    @Deprecated(forRemoval = true)
     int getItemDespawnTime();
+
+    default int getItemDespawnTime(ItemEntity entity) {
+        return this.getItemDespawnTime();
+    }
 
     boolean isUrgentFlashEnabled();
 }

--- a/common/src/main/java/io/github/strikerrocker/cleardespawn/RenderItemEntityExtended.java
+++ b/common/src/main/java/io/github/strikerrocker/cleardespawn/RenderItemEntityExtended.java
@@ -14,7 +14,7 @@ public class RenderItemEntityExtended extends ItemEntityRenderer {
 
     @Override
     public void render(ItemEntity entity, float entityYaw, float partialTicks, PoseStack matrixStack, MultiBufferSource buffer, int packedLight) {
-        int remainingTime = Services.CONFIG_HELPER.getItemDespawnTime() - entity.getAge();
+        int remainingTime = Services.CONFIG_HELPER.getItemDespawnTime(entity) - entity.getAge();
         if (remainingTime <= 20 * Services.CONFIG_HELPER.getFlashStartTime()) {
             if (Services.CONFIG_HELPER.isUrgentFlashEnabled()) {
                 int flashFactor = Math.max(2, remainingTime / 20);

--- a/fabric/src/main/java/io/github/strikerrocker/cleardespawn/ConfigHelper.java
+++ b/fabric/src/main/java/io/github/strikerrocker/cleardespawn/ConfigHelper.java
@@ -1,5 +1,7 @@
 package io.github.strikerrocker.cleardespawn;
 
+import net.minecraft.world.entity.item.ItemEntity;
+
 public class ConfigHelper implements IConfigHelper {
     @Override
     public int getFlashStartTime() {
@@ -7,7 +9,7 @@ public class ConfigHelper implements IConfigHelper {
     }
 
     @Override
-    public int getItemDespawnTime() {
+    public int getItemDespawnTime(ItemEntity entity) {
         return ClearDespawn.config.despawnTime;
     }
 

--- a/forge/src/main/java/io/github/strikerrocker/cleardespawn/Config.java
+++ b/forge/src/main/java/io/github/strikerrocker/cleardespawn/Config.java
@@ -16,13 +16,14 @@ public class Config {
     public static class ClientConfig {
 
         public final ForgeConfigSpec.IntValue flashStartTime;
+        @Deprecated(forRemoval = true)
         public final ForgeConfigSpec.IntValue despawnTime;
         public final ForgeConfigSpec.BooleanValue urgentFlash;
 
         ClientConfig(ForgeConfigSpec.Builder builder) {
             builder.push("general");
             flashStartTime = builder.comment("Blinking start time before the item despawns, in seconds").defineInRange("flashStartTime", 20, 0, 36000);
-            despawnTime = builder.comment("Time until items will despawn (Change only if the items in the pack have different time limit)").defineInRange("despawnTime", 6000, 0, 36000);
+            despawnTime = builder.comment("[DEPRECATED] Time until items will despawn (Change only if the items in the pack have different time limit)").defineInRange("despawnTime", 6000, 0, 36000);
             urgentFlash = builder.comment("Set to true to have item flash faster as it gets closer to despawning").define("urgentFlash", true);
             builder.pop();
         }

--- a/forge/src/main/java/io/github/strikerrocker/cleardespawn/Config.java
+++ b/forge/src/main/java/io/github/strikerrocker/cleardespawn/Config.java
@@ -16,14 +16,11 @@ public class Config {
     public static class ClientConfig {
 
         public final ForgeConfigSpec.IntValue flashStartTime;
-        @Deprecated(forRemoval = true)
-        public final ForgeConfigSpec.IntValue despawnTime;
         public final ForgeConfigSpec.BooleanValue urgentFlash;
 
         ClientConfig(ForgeConfigSpec.Builder builder) {
             builder.push("general");
             flashStartTime = builder.comment("Blinking start time before the item despawns, in seconds").defineInRange("flashStartTime", 20, 0, 36000);
-            despawnTime = builder.comment("[DEPRECATED] Time until items will despawn (Change only if the items in the pack have different time limit)").defineInRange("despawnTime", 6000, 0, 36000);
             urgentFlash = builder.comment("Set to true to have item flash faster as it gets closer to despawning").define("urgentFlash", true);
             builder.pop();
         }

--- a/forge/src/main/java/io/github/strikerrocker/cleardespawn/ConfigHelper.java
+++ b/forge/src/main/java/io/github/strikerrocker/cleardespawn/ConfigHelper.java
@@ -1,5 +1,7 @@
 package io.github.strikerrocker.cleardespawn;
 
+import net.minecraft.world.entity.item.ItemEntity;
+
 public class ConfigHelper implements IConfigHelper {
     @Override
     public int getFlashStartTime() {
@@ -9,6 +11,11 @@ public class ConfigHelper implements IConfigHelper {
     @Override
     public int getItemDespawnTime() {
         return Config.CLIENT.despawnTime.get();
+    }
+
+    @Override
+    public int getItemDespawnTime(ItemEntity entity) {
+        return entity.lifespan;
     }
 
     @Override

--- a/forge/src/main/java/io/github/strikerrocker/cleardespawn/ConfigHelper.java
+++ b/forge/src/main/java/io/github/strikerrocker/cleardespawn/ConfigHelper.java
@@ -9,11 +9,6 @@ public class ConfigHelper implements IConfigHelper {
     }
 
     @Override
-    public int getItemDespawnTime() {
-        return Config.CLIENT.despawnTime.get();
-    }
-
-    @Override
     public int getItemDespawnTime(ItemEntity entity) {
         return entity.lifespan;
     }


### PR DESCRIPTION
In Forge, the lifespan check will now look at `Entity#lifespan` instead of the configuration since items can have differing lifespans per implementation. The check in Fabric remains the same as there is no common API.

The configuration options in Forge have been deprecated for removal but not removed to maintain compatibility. The `#getItemDespawnTime` without being entity sensitive also remains for this reason.